### PR TITLE
Bump sharp to 0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "glob": "^6.0.0",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
-    "sharp": "^0.17"
+    "sharp": "^0.18"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi, we needed to update sharp to 0.18, because 0.17 had hardcoded download URL for vips, which no longer existed (https://dl.bintray.com/lovell/sharp/libvips-8.2.0-lin.tar.gz) and it completely broke our deploys on Heroku.